### PR TITLE
serial console as default

### DIFF
--- a/scripts/lib/wic/canned-wks/systemd-bootdisk-uuid.wks
+++ b/scripts/lib/wic/canned-wks/systemd-bootdisk-uuid.wks
@@ -8,4 +8,4 @@ part / --source rootfs --ondisk sda --fstype=ext4 --label platform --align 1024 
 
 part swap --ondisk sda --size 44 --label swap1 --fstype=swap
 
-bootloader --ptable gpt --timeout=5 --append="rootwait rootfstype=ext4 console=tty0"
+bootloader --ptable gpt --timeout=5 --append="rootwait rootfstype=ext4 console=ttyS0,115200"


### PR DESCRIPTION
Both on simulator (ASE/Simics) and real targets we use serial console.

Signed-off-by: Per Hallsmark <per.hallsmark@windriver.com>